### PR TITLE
Added Button, Input and Link components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Link from './components/Link'
 function App (): ReactElement {
   return <>
     <h1 className="text-4xl font-bold">Lunchify</h1>
-    <Input type='text' />
+    <Input text='Enter a song name' type='text' />
     <Button text='Play' bgColor="bg-green-500" />
     <Link text="Link" link="https://www.google.com" />
   </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,14 @@
 import { ReactElement } from 'react'
+import Button from './components/Button'
+import Input from './components/Input'
+import Link from './components/Link'
 
 function App (): ReactElement {
   return <>
-      <h1 className="text-4xl font-bold">Lunchify</h1>
+    <h1 className="text-4xl font-bold">Lunchify</h1>
+    <Input type='text' />
+    <Button text='Play' bgColor="bg-green-500" />
+    <Link text="Link" link="https://www.google.com" />
   </>
 }
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+interface ButtonProps {
+  text: string
+  bgColor: string
+}
+
+const Button: React.FunctionComponent<ButtonProps> = ({ text = 'Button text', bgColor = 'bg-green-500' }: ButtonProps) => {
+  return (
+    <button className={`hover:scale-105 text-white font-medium my-4 py-2 px-8 rounded-full ${bgColor}`}>{ text }</button>
+  )
+}
+
+export default Button

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 
 interface InputProps {
   type: string
+  text: string
 }
 
-const Input: React.FunctionComponent<InputProps> = ({ type = "text" }: InputProps) => {
+const Input: React.FunctionComponent<InputProps> = ({ text = 'Input text', type = 'text' }: InputProps) => {
   return (
-    <input className="block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm" type={ type } placeholder="Enter song or artist name" />
+    <input className='block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm' type = { type } placeholder = {`${text}`} />
   )
 }
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+interface InputProps {
+  type: string
+}
+
+const Input: React.FunctionComponent<InputProps> = ({ type = "text" }: InputProps) => {
+  return (
+    <input className="block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm" type={ type } placeholder="Enter song or artist name" />
+  )
+}
+
+export default Input

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+interface LinkProps {
+  text: string
+  link: string
+}
+
+const Link: React.FunctionComponent<LinkProps> = ({ text = 'Link text', link = '' }: LinkProps) => {
+  return (
+    <a className='hover:underline font-medium' href={ link } target="_blank">{ text }</a>
+  )
+}
+
+export default Link


### PR DESCRIPTION
<!-- Provide a general summary of your changes below -->
Added Button, Input and Link components for the Lunchify app.

## Description
The Button component has a text and bgColor prop where you can enter the button text and background color using the Tailwind bg-color syntax, e.g. bg-green-500. The Input component has a text and type prop where you can enter the input placeholder text and the type of the input field, e.g. text. The Link component has a text and link prop where you can enter the link text and url of the link to navigate to.

## Related Issue
Shared components
[<!-- Please link to the issue here: -->](https://github.com/fergcb/lunchify/issues/2)

## Motivation and Context
To provide standard components that have a similar theme across the Lunchify app.

## How Has This Been Tested?
Using ESLint to test syntax and created a Button, Link and Input component in App.js to make sure they render properly.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
