### PR TITLE
Added props and children to Input, Link and Button components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import Link from './components/Link'
 function App (): ReactElement {
   return <>
     <h1 className="text-4xl font-bold">Lunchify</h1>
-    <Input type='text' />
+    <Input text='Enter a song name' type='text' />
     <Button text='Play' bgColor="bg-green-500" />
     <Link text="Link" link="https://www.google.com" />
   </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,8 @@ function App (): ReactElement {
   return <>
     <h1 className="text-4xl font-bold">Lunchify</h1>
     <Input text='Enter a song name' type='text' />
-    <Button text='Play' bgColor="bg-green-500" />
-    <Link text="Link" link="https://www.google.com" />
+    <Button bgColor="bg-green-500">Buton text</Button>
+    <Link link="https://www.google.com">Link</Link>
   </>
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,14 @@
 import { ReactElement } from 'react'
+import Button from './components/Button'
+import Input from './components/Input'
+import Link from './components/Link'
 
 function App (): ReactElement {
   return <>
-      <h1 className="text-4xl font-bold">Lunchify</h1>
+    <h1 className="text-4xl font-bold">Lunchify</h1>
+    <Input type='text' />
+    <Button text='Play' bgColor="bg-green-500" />
+    <Link text="Link" link="https://www.google.com" />
   </>
 }
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+interface ButtonProps {
+  text: string
+  bgColor: string
+}
+
+const Button: React.FunctionComponent<ButtonProps> = ({ text = 'Button text', bgColor = 'bg-green-500' }: ButtonProps) => {
+  return (
+    <button className={`hover:scale-105 text-white font-medium my-4 py-2 px-8 rounded-full ${bgColor}`}>{ text }</button>
+  )
+}
+
+export default Button

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 
-interface ButtonProps {
-  text: string
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   bgColor: string
 }
 
-const Button: React.FunctionComponent<ButtonProps> = ({ text = 'Button text', bgColor = 'bg-green-500' }: ButtonProps) => {
+const Button: React.FunctionComponent<ButtonProps> = ({ bgColor = 'bg-green-500', children, ...props }: ButtonProps) => {
   return (
-    <button className={`hover:scale-105 text-white font-medium my-4 py-2 px-8 rounded-full ${bgColor}`}>{ text }</button>
+    <button {...props} className={`hover:scale-105 text-white font-medium my-4 py-2 px-8 rounded-full ${bgColor}`}>{ children }</button>
   )
 }
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -2,11 +2,12 @@ import React from 'react'
 
 interface InputProps {
   type: string
+  text: string
 }
 
-const Input: React.FunctionComponent<InputProps> = ({ type = "text" }: InputProps) => {
+const Input: React.FunctionComponent<InputProps> = ({ text = 'Input text', type = 'text' }: InputProps) => {
   return (
-    <input className="block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm" type={ type } placeholder="Enter song or artist name" />
+    <input className='block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm' type = { type } placeholder = {`${text}`} />
   )
 }
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 
-interface InputProps {
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type: string
   text: string
 }
 
-const Input: React.FunctionComponent<InputProps> = ({ text = 'Input text', type = 'text' }: InputProps) => {
+const Input: React.FunctionComponent<InputProps> = ({ text = 'Input text', type = 'text', ...props }: InputProps) => {
   return (
-    <input className='block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm' type = { type } placeholder = {`${text}`} />
+    <input {...props} className='block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm' type = { type } placeholder = {`${text}`} />
   )
 }
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+interface InputProps {
+  type: string
+}
+
+const Input: React.FunctionComponent<InputProps> = ({ type = "text" }: InputProps) => {
+  return (
+    <input className="block font-medium w-full rounded-full border-2 border-zinc-900 pl-7 pr-12 py-2 px-8 sm:text-sm" type={ type } placeholder="Enter song or artist name" />
+  )
+}
+
+export default Input

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -7,7 +7,7 @@ interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 
 const Link: React.FunctionComponent<LinkProps> = ({ link = '', external = false, children, ...props }: LinkProps) => {
   return (
-    <a {...props} className='hover:underline font-medium' href={ link } target={external ? '_blank' : ''}>{ children }</a>
+    <a {...props} className='hover:underline font-medium' href={ link } target={external ? '_blank' : ''} rel="noreferrer">{ children }</a>
   )
 }
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+interface LinkProps {
+  text: string
+  link: string
+}
+
+const Link: React.FunctionComponent<LinkProps> = ({ text = 'Link text', link = '' }: LinkProps) => {
+  return (
+    <a className='hover:underline font-medium' href={ link } target="_blank">{ text }</a>
+  )
+}
+
+export default Link

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,13 +1,13 @@
-import React from 'react'
+import React, { AnchorHTMLAttributes } from 'react'
 
-interface LinkProps {
-  text: string
+interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   link: string
+  external?: boolean
 }
 
-const Link: React.FunctionComponent<LinkProps> = ({ text = 'Link text', link = '' }: LinkProps) => {
+const Link: React.FunctionComponent<LinkProps> = ({ link = '', external = false, children, ...props }: LinkProps) => {
   return (
-    <a className='hover:underline font-medium' href={ link } target="_blank">{ text }</a>
+    <a {...props} className='hover:underline font-medium' href={ link } target={external ? '_blank' : ''}>{ children }</a>
   )
 }
 

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -7,7 +7,7 @@ interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 
 const Link: React.FunctionComponent<LinkProps> = ({ link = '', external = false, children, ...props }: LinkProps) => {
   return (
-    <a {...props} className='hover:underline font-medium' href={ link } target={external ? '_blank' : ''} rel="noreferrer">{ children }</a>
+    <a {...props} className='hover:underline font-medium' href={ link } target={external ? '_blank' : ''} rel='noreferrer'>{ children }</a>
   )
 }
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes below -->
Added props and children to Input, Link and Button components

## Description
Added children to Link and Button components to allow text to be entered in between Link and Button tags. Added props to Link, Input and Button components to enable access to relevant attributes for components, e.g. disabled on buttons.

## Related Issue
[<!-- Please link to the issue here: -->](https://github.com/fergcb/lunchify/issues/2)

## Motivation and Context
Enables access to relevant HTML attributes, such as disabled for buttons. Also allows text to be written in between Link and Button tags.

## How Has This Been Tested?
By adding it to App.js and making sure ESLint doesn't throw any errors.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
