### PR TITLE
Add POST, PUT methods to SpotifyClient

### DIFF
--- a/src/api/SpotifyClient.ts
+++ b/src/api/SpotifyClient.ts
@@ -13,7 +13,7 @@ export default class SpotifyClient {
     if (!api.auth.ready) throw new Error(`Request to '${resource}' forbidden: client must be authenticated.`)
 
     return await fetch(
-      new URL(resource, this.baseURL),
+      this.baseURL + resource,
       {
         ...options,
         headers: {

--- a/src/api/SpotifyClient.ts
+++ b/src/api/SpotifyClient.ts
@@ -9,18 +9,29 @@ export default class SpotifyClient {
     auth.init()
   }
 
-  async get (resource: string, options: RequestInit = {}): Promise<Response> {
+  async fetch (resource: string, options: RequestInit = {}): Promise<Response> {
     if (!api.auth.ready) throw new Error(`Request to '${resource}' forbidden: client must be authenticated.`)
 
     return await fetch(
       new URL(resource, this.baseURL),
       {
         ...options,
-        method: 'GET',
         headers: {
           Authorization: `Bearer ${this.auth.token}`,
         },
       },
     )
+  }
+
+  async get (resource: string, options: RequestInit = {}): Promise<Response> {
+    return await this.fetch(resource, { ...options, method: 'GET' })
+  }
+
+  async post (resource: string, options: RequestInit = {}): Promise<Response> {
+    return await this.fetch(resource, { ...options, method: 'POST' })
+  }
+
+  async put (resource: string, options: RequestInit = {}): Promise<Response> {
+    return await this.fetch(resource, { ...options, method: 'PUT' })
   }
 }


### PR DESCRIPTION
## Summary
<!-- Describe your changes, what they do, how they do it, and why. -->
<!-- If you have made changes to the UI, please provide screenshots. -->
This PR adds a generic `fetch` method to the SpotifyClient class, which makes an authenticated HTTP request to the Spotify API.

The `fetch` method is used to refactor the `get` method, as well as to implement `post` and `put` methods corresponding to the HTTP methods of the same names.

## Related Issue
<!-- Link the issue this PR resolves by putting its number after the #. -->
<!-- If there is no related issue, explain why the PR is needed. -->
Resolves N/A
No issue. Change is needed to facilitate calls to POST/PUT endpoints, e.g. for playback.

## How Has This Been Tested?
<!-- Please describe how you tested your changes. -->
Ad-hoc, locally

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation, if necessary.
